### PR TITLE
Update Chargen Parts.json

### DIFF
--- a/rmd/Chargen Parts.json
+++ b/rmd/Chargen Parts.json
@@ -81,27 +81,27 @@
   },
   "440016": {
     "OriginalText": "キャスト男性顔ベースＡ",
-    "Text": "Base Cast Male Face A",
+    "Text": "Base CAST Male Face A",
     "Enabled": true
   },
   "440017": {
     "OriginalText": "キャスト男性顔ベースＢ",
-    "Text": "Base Cast Male Face B",
+    "Text": "Base CAST Male Face B",
     "Enabled": true
   },
   "440018": {
     "OriginalText": "キャスト男性顔ベースＣ",
-    "Text": "Base Cast Male Face C",
+    "Text": "Base CAST Male Face C",
     "Enabled": true
   },
   "440019": {
     "OriginalText": "キャスト男性顔ベースＤ",
-    "Text": "Base Cast Male Face D",
+    "Text": "Base CAST Male Face D",
     "Enabled": true
   },
   "440020": {
     "OriginalText": "キャスト男性顔ベースＥ",
-    "Text": "Base Cast Male Face E",
+    "Text": "Base CAST Male Face E",
     "Enabled": true
   },
   "440021": {
@@ -121,27 +121,27 @@
   },
   "440024": {
     "OriginalText": "キャスト男性顔ベースＦ",
-    "Text": "Base Cast Male Face F",
+    "Text": "Base CAST Male Face F",
     "Enabled": true
   },
   "440025": {
     "OriginalText": "ロニア・ヘッド破",
-    "Text": "Broken Ronia Head",
+    "Text": "Ronia Head (Damaged)",
     "Enabled": true
   },
   "440026": {
     "OriginalText": "ディスタ・ヘッド破",
-    "Text": "Broken Dista Head",
+    "Text": "Dista Head (Damaged)",
     "Enabled": true
   },
   "440027": {
     "OriginalText": "ファウマ・ヘッド破",
-    "Text": "Broken Fauma Head",
+    "Text": "Fauma Head (Damaged)",
     "Enabled": true
   },
   "440028": {
     "OriginalText": "アングリフ・ヘッド破",
-    "Text": "Broken Angriff Head",
+    "Text": "Angriff Head (Damaged)",
     "Enabled": true
   },
   "440029": {
@@ -151,12 +151,12 @@
   },
   "440030": {
     "OriginalText": "マギウス・ヘッド破",
-    "Text": "Broken Magius Head",
+    "Text": "Magius Head (Damaged)",
     "Enabled": true
   },
   "440031": {
     "OriginalText": "シェリフ・ヘッド破",
-    "Text": "Broken Sheriff Head",
+    "Text": "Sheriff Head (Damaged)",
     "Enabled": true
   },
   "440032": {
@@ -171,22 +171,22 @@
   },
   "440034": {
     "OriginalText": "フィルフ・ヘッド破",
-    "Text": "Broken Fliph Head",
+    "Text": "Fliph Head (Damaged)",
     "Enabled": true
   },
   "440035": {
     "OriginalText": "ヒュリオン・ヘッド破",
-    "Text": "Broken Hurion Head",
+    "Text": "Hurion Head (Damaged)",
     "Enabled": true
   },
   "440036": {
     "OriginalText": "メルダー・ヘッド破",
-    "Text": "Broken Melder Head",
+    "Text": "Melder Head (Damaged)",
     "Enabled": true
   },
   "440037": {
     "OriginalText": "アラオ・ヘッド破",
-    "Text": "Broken Arao Head",
+    "Text": "Arao Head (Damaged)",
     "Enabled": true
   },
   "440038": {
@@ -266,22 +266,22 @@
   },
   "440053": {
     "OriginalText": "キャスト女性顔ベースＡ",
-    "Text": "Base Cast Female Face A",
+    "Text": "Base CAST Female Face A",
     "Enabled": true
   },
   "440054": {
     "OriginalText": "キャスト女性顔ベースＢ",
-    "Text": "Base Cast Female Face B",
+    "Text": "Base CAST Female Face B",
     "Enabled": true
   },
   "440055": {
     "OriginalText": "キャスト女性顔ベースＣ",
-    "Text": "Base Cast Female Face C",
+    "Text": "Base CAST Female Face C",
     "Enabled": true
   },
   "440056": {
     "OriginalText": "キャスト女性顔ベースＤ",
-    "Text": "Base Cast Female Face D",
+    "Text": "Base CAST Female Face D",
     "Enabled": true
   },
   "440057": {
@@ -301,7 +301,7 @@
   },
   "440060": {
     "OriginalText": "キャスト女性顔ベースＥ",
-    "Text": "Base Cast Female Face E",
+    "Text": "Base CAST Female Face E",
     "Enabled": true
   },
   "440061": {
@@ -321,28 +321,28 @@
   },
   "440064": {
     "OriginalText": "キャスト女性用アニメ系",
-    "Text": "Cast Female Animation System",
+    "Text": "CAST Female Animation System",
     "Enabled": true
   },
   "440065": {
     "OriginalText": "ヒューマン女性顔ベースＥ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Base Human Female Face E",
+    "Enabled": true
   },
   "440066": {
     "OriginalText": "ニューマン女性顔ベースＩ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Base Newman Female Face I",
+    "Enabled": true
   },
   "440067": {
     "OriginalText": "ニューマン女性顔ベースＪ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Base Newman Female Face J",
+    "Enabled": true
   },
   "440068": {
     "OriginalText": "キャスト女性顔ベースＦ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Base CAST Female Face F",
+    "Enabled": true
   },
   "440069": {
     "OriginalText": "セイル",
@@ -416,8 +416,8 @@
   },
   "440083": {
     "OriginalText": "シャロン用フェイス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Sharon Face",
+    "Enabled": true
   },
   "440084": {
     "OriginalText": "人型用 タイプＡ 大",
@@ -501,83 +501,83 @@
   },
   "440100": {
     "OriginalText": "タイプＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type A",
+    "Enabled": true
   },
   "440101": {
     "OriginalText": "タイプＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type B",
+    "Enabled": true
   },
   "440102": {
     "OriginalText": "タイプＣ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type C",
+    "Enabled": true
   },
   "440103": {
     "OriginalText": "タイプＤ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type D",
+    "Enabled": true
   },
   "440104": {
     "OriginalText": "タイプＥ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type E",
+    "Enabled": true
   },
   "440105": {
     "OriginalText": "タイプＦ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type F",
+    "Enabled": true
   },
   "440106": {
     "OriginalText": "タイプＧ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type G",
+    "Enabled": true
   },
   "440107": {
     "OriginalText": "タイプＨ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type H",
+    "Enabled": true
   },
   "440108": {
     "OriginalText": "タイプＩ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type I",
+    "Enabled": true
   },
   "440109": {
     "OriginalText": "タイプＪ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type J",
+    "Enabled": true
   },
   "440110": {
     "OriginalText": "タイプＫ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type K",
+    "Enabled": true
   },
   "440111": {
     "OriginalText": "タイプＬ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type L",
+    "Enabled": true
   },
   "440112": {
     "OriginalText": "タイプＭ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type M",
+    "Enabled": true
   },
   "440113": {
     "OriginalText": "タイプＮ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type N",
+    "Enabled": true
   },
   "440114": {
     "OriginalText": "タイプＯ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type O",
+    "Enabled": true
   },
   "440115": {
     "OriginalText": "タイプＰ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type P",
+    "Enabled": true
   },
   "440116": {
     "OriginalText": "太飼",
@@ -591,428 +591,428 @@
   },
   "440118": {
     "OriginalText": "人型用 タイプＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type A",
+    "Enabled": true
   },
   "440119": {
     "OriginalText": "人型用 タイプＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type B",
+    "Enabled": true
   },
   "440120": {
     "OriginalText": "人型用 タイプＣ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type C",
+    "Enabled": true
   },
   "440121": {
     "OriginalText": "人型用 タイプＤ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type D",
+    "Enabled": true
   },
   "440122": {
     "OriginalText": "人型用 タイプＥ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type E",
+    "Enabled": true
   },
   "440123": {
     "OriginalText": "人型用 タイプＦ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type F",
+    "Enabled": true
   },
   "440124": {
     "OriginalText": "人型用 タイプＧ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type G",
+    "Enabled": true
   },
   "440125": {
     "OriginalText": "人型用 タイプＨ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type H",
+    "Enabled": true
   },
   "440126": {
     "OriginalText": "人型用 タイプＩ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type I",
+    "Enabled": true
   },
   "440127": {
     "OriginalText": "人型用 タイプＪ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type J",
+    "Enabled": true
   },
   "440128": {
     "OriginalText": "人型用 タイプＫ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type K",
+    "Enabled": true
   },
   "440129": {
     "OriginalText": "人型用 タイプＬ",
-    "Text": "",
+    "Text": "Type L",
     "Enabled": false
   },
   "440130": {
     "OriginalText": "人型用 タイプＭ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type M",
+    "Enabled": true
   },
   "440131": {
     "OriginalText": "人型用 タイプＮ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type N",
+    "Enabled": true
   },
   "440132": {
     "OriginalText": "キャスト用 タイプＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type A",
+    "Enabled": true
   },
   "440133": {
     "OriginalText": "キャスト用 タイプＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type B",
+    "Enabled": true
   },
   "440134": {
     "OriginalText": "キャスト用 タイプＣ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type C",
+    "Enabled": true
   },
   "440135": {
     "OriginalText": "キャスト用 タイプＤ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type D",
+    "Enabled": true
   },
   "440136": {
     "OriginalText": "キャスト用 タイプＥ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Type E",
+    "Enabled": true
   },
   "440137": {
     "OriginalText": "ローズ・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rose Head (Damaged)",
+    "Enabled": true
   },
   "440138": {
     "OriginalText": "ディール・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Deal Head (Damaged)",
+    "Enabled": true
   },
   "440139": {
     "OriginalText": "ファーネン・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fanen Head (Damaged)",
+    "Enabled": true
   },
   "440140": {
     "OriginalText": "イオニア・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ionia Head (Damaged)",
+    "Enabled": true
   },
   "440141": {
     "OriginalText": "ランクス・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ranks Head",
+    "Enabled": true
   },
   "440142": {
     "OriginalText": "イルシオン・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Illusion Head",
+    "Enabled": true
   },
   "440143": {
     "OriginalText": "ワスプ・ヘッド破ＣＶ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Wasp Head CV (Damaged)",
+    "Enabled": true
   },
   "440144": {
     "OriginalText": "フリーゲン・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fliegen Head (Damaged)",
+    "Enabled": true
   },
   "440145": {
     "OriginalText": "ラミア・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lamia Head (Damaged)",
+    "Enabled": true
   },
   "440146": {
     "OriginalText": "グリース・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Griss Head (Damaged)",
+    "Enabled": true
   },
   "440147": {
     "OriginalText": "ケルビナ・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Cherubina Head (Damaged)",
+    "Enabled": true
   },
   "440148": {
     "OriginalText": "メディウム・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Head",
+    "Enabled": true
   },
   "440149": {
     "OriginalText": "ヘルマ・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Helma Head (Damaged)",
+    "Enabled": true
   },
   "440150": {
     "OriginalText": "ゴルドファム・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Gold Fam Head",
+    "Enabled": true
   },
   "440151": {
     "OriginalText": "ガラテ・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Garate Head",
+    "Enabled": true
   },
   "440152": {
     "OriginalText": "アルキ・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Head",
+    "Enabled": true
   },
   "440153": {
     "OriginalText": "ラビーソ・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rabiso Head",
+    "Enabled": true
   },
   "440154": {
     "OriginalText": "マーヴ・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Marv Head",
+    "Enabled": true
   },
   "440155": {
     "OriginalText": "ノヴァファム・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Fam Head",
+    "Enabled": true
   },
   "440156": {
     "OriginalText": "シャロン・ヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Sharon Head",
+    "Enabled": true
   },
   "440157": {
     "OriginalText": "ベリーショート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Very Short",
+    "Enabled": true
   },
   "440158": {
     "OriginalText": "ショートマッシュ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Short Mash",
+    "Enabled": true
   },
   "440159": {
     "OriginalText": "スパイキーウルフ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Spiky Wolf",
+    "Enabled": true
   },
   "440160": {
     "OriginalText": "カジュアル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casual",
+    "Enabled": true
   },
   "440161": {
     "OriginalText": "ショートウルフ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Short Wolf",
+    "Enabled": true
   },
   "440162": {
     "OriginalText": "ミディアムレイヤー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Layer",
+    "Enabled": true
   },
   "440163": {
     "OriginalText": "ブレイズ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blaze",
+    "Enabled": true
   },
   "440164": {
     "OriginalText": "クラシックショート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Classic Short",
+    "Enabled": true
   },
   "440165": {
     "OriginalText": "スパイク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Spike",
+    "Enabled": true
   },
   "440166": {
     "OriginalText": "サムライポニー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Samurai Pony",
+    "Enabled": true
   },
   "440167": {
     "OriginalText": "シャープストレート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Sharp Straight",
+    "Enabled": true
   },
   "440168": {
     "OriginalText": "ビグテール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Big Tail",
+    "Enabled": true
   },
   "440169": {
     "OriginalText": "ウェーブ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Wave",
+    "Enabled": true
   },
   "440170": {
     "OriginalText": "リーゼント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Resent",
+    "Enabled": true
   },
   "440171": {
     "OriginalText": "ショートストレート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Short Straight",
+    "Enabled": true
   },
   "440172": {
     "OriginalText": "カジュアルレイヤー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casual Layer",
+    "Enabled": true
   },
   "440173": {
     "OriginalText": "ストレートロング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Straight Long",
+    "Enabled": true
   },
   "440174": {
     "OriginalText": "ミディアムマッシュ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Mash",
+    "Enabled": true
   },
   "440175": {
     "OriginalText": "ショートボブ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Short Bob",
+    "Enabled": true
   },
   "440176": {
     "OriginalText": "レトロガーリー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Retro Girly",
+    "Enabled": true
   },
   "440177": {
     "OriginalText": "オールバック",
-    "Text": "",
-    "Enabled": false
+    "Text": "All Back",
+    "Enabled": true
   },
   "440178": {
     "OriginalText": "ふんわりアフロ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fluffy Afro",
+    "Enabled": true
   },
   "440179": {
     "OriginalText": "モヒカン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Mohawk",
+    "Enabled": true
   },
   "440180": {
     "OriginalText": "中分けショートボブ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Middle-Parted Short Bob",
+    "Enabled": true
   },
   "440181": {
     "OriginalText": "ワイルドポニー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Wild Pony",
+    "Enabled": true
   },
   "440182": {
     "OriginalText": "ショートリーゼント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Short Resent",
+    "Enabled": true
   },
   "440183": {
     "OriginalText": "スキンヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Skinhead",
+    "Enabled": true
   },
   "440184": {
     "OriginalText": "ミディアムクール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Cool",
+    "Enabled": true
   },
   "440185": {
     "OriginalText": "ミディアムエッジ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Edge",
+    "Enabled": true
   },
   "440186": {
     "OriginalText": "クラシックオールバック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Classic All Back",
+    "Enabled": true
   },
   "440187": {
     "OriginalText": "外ハネセミロング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Outward Combed Semi-Long",
+    "Enabled": true
   },
   "440188": {
     "OriginalText": "ヘリパイロットヘルメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Heli Pilot Helmet",
+    "Enabled": true
   },
   "440189": {
     "OriginalText": "ヘリＰヘルメットＮＶ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Heli Pilot Helmet NV",
+    "Enabled": true
   },
   "440190": {
     "OriginalText": "リリーパヘアー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lilipa Hair",
+    "Enabled": true
   },
   "440191": {
     "OriginalText": "ツインテール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Twin Tails",
+    "Enabled": true
   },
   "440192": {
     "OriginalText": "ナチュラルロング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Natural Long",
+    "Enabled": true
   },
   "440193": {
     "OriginalText": "アップスタイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Up Style",
+    "Enabled": true
   },
   "440194": {
     "OriginalText": "サイドアップ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Side Up",
+    "Enabled": true
   },
   "440195": {
     "OriginalText": "ミディアムツインテール１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Twin Tails 1",
+    "Enabled": true
   },
   "440196": {
     "OriginalText": "ミディアムツインテール２",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Twin Tails 2",
+    "Enabled": true
   },
   "440197": {
     "OriginalText": "ポニーテール１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ponytail 1",
+    "Enabled": true
   },
   "440198": {
     "OriginalText": "ポニーテール２",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ponytail 2",
+    "Enabled": true
   },
   "440199": {
     "OriginalText": "ポニーテール３",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ponytail 3",
+    "Enabled": true
   },
   "440200": {
     "OriginalText": "ミディアムストレート１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Straight 1",
+    "Enabled": true
   },
   "440201": {
     "OriginalText": "ミディアムストレート２",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Straight 2",
+    "Enabled": true
   },
   "440202": {
     "OriginalText": "ミディアムストレート３",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Straight 3",
+    "Enabled": true
   },
   "440203": {
     "OriginalText": "ゆる三つ編み",
@@ -1026,8 +1026,8 @@
   },
   "440205": {
     "OriginalText": "ツインアップ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Twin Up",
+    "Enabled": true
   },
   "440206": {
     "OriginalText": "編みこみアップスタイル",
@@ -1036,98 +1036,98 @@
   },
   "440207": {
     "OriginalText": "ロングツインテール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Long Twin Tails",
+    "Enabled": true
   },
   "440208": {
     "OriginalText": "たれツインテ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Low Twin Tails",
+    "Enabled": true
   },
   "440209": {
     "OriginalText": "イーリスビーハイブ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Iris Beehive",
+    "Enabled": true
   },
   "440210": {
     "OriginalText": "姫カットロング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Hime Cut Long",
+    "Enabled": true
   },
   "440211": {
     "OriginalText": "スーパーパイナップル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Super Pineapple",
+    "Enabled": true
   },
   "440212": {
     "OriginalText": "セブンスリーヘア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Seven Three Hair",
+    "Enabled": true
   },
   "440213": {
     "OriginalText": "ヤワフアミディアム",
-    "Text": "",
-    "Enabled": false
+    "Text": "Yawafua Medium",
+    "Enabled": true
   },
   "440214": {
     "OriginalText": "ビジネスマッシュボブ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Business Mash Bob",
+    "Enabled": true
   },
   "440215": {
     "OriginalText": "ニュアンスストレート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nuance Straight",
+    "Enabled": true
   },
   "440216": {
     "OriginalText": "ドレスアップヘア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Dress Up Hair",
+    "Enabled": true
   },
   "440217": {
     "OriginalText": "フェミニンロング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Feminine Long",
+    "Enabled": true
   },
   "440218": {
     "OriginalText": "フェミニンロングブライド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Feminine Long Bright",
+    "Enabled": true
   },
   "440219": {
     "OriginalText": "クイーンズロング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Queens Long",
+    "Enabled": true
   },
   "440220": {
     "OriginalText": "トロピカルストレート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tropical Straight",
+    "Enabled": true
   },
   "440221": {
     "OriginalText": "スパイスタイルオールバック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Spy Style All Back",
+    "Enabled": true
   },
   "440222": {
     "OriginalText": "ロングパイルスタイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Long Pile Style",
+    "Enabled": true
   },
   "440223": {
     "OriginalText": "ショートモヒカンスタイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Short Mohawk Style",
+    "Enabled": true
   },
   "440224": {
     "OriginalText": "カジュアルパーティスタイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casual Party Style",
+    "Enabled": true
   },
   "440225": {
     "OriginalText": "ナイトパーティスタイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Night Party Style",
+    "Enabled": true
   },
   "440241": {
     "OriginalText": "なし",
@@ -1136,18 +1136,18 @@
   },
   "440242": {
     "OriginalText": "フェイスガード 白",
-    "Text": "",
-    "Enabled": false
+    "Text": "White Face Guard",
+    "Enabled": true
   },
   "440243": {
     "OriginalText": "フェイスガード グレー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Grey Face Guard",
+    "Enabled": true
   },
   "440244": {
     "OriginalText": "フェイスガード ブラック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Black Face Guard",
+    "Enabled": true
   },
   "440245": {
     "OriginalText": "鼻ばんそうこう",
@@ -1156,23 +1156,23 @@
   },
   "440246": {
     "OriginalText": "タトゥー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tattoo",
+    "Enabled": true
   },
   "440247": {
     "OriginalText": "ヒゲ１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beard 1",
+    "Enabled": true
   },
   "440248": {
     "OriginalText": "ヒゲ２",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beard 2",
+    "Enabled": true
   },
   "440249": {
     "OriginalText": "無精ひげ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Stubble",
+    "Enabled": true
   },
   "440250": {
     "OriginalText": "隈取",
@@ -1181,118 +1181,118 @@
   },
   "440251": {
     "OriginalText": "カモフラージュペイント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Camouflage Paint",
+    "Enabled": true
   },
   "440252": {
     "OriginalText": "ドクロペイント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Skull Paint",
+    "Enabled": true
   },
   "440253": {
     "OriginalText": "プリティフラワー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Pretty Flower",
+    "Enabled": true
   },
   "440254": {
     "OriginalText": "傷跡１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scar 1",
+    "Enabled": true
   },
   "440255": {
     "OriginalText": "傷跡２",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scar 2",
+    "Enabled": true
   },
   "440256": {
     "OriginalText": "傷跡３",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scar 3",
+    "Enabled": true
   },
   "440257": {
     "OriginalText": "傷跡４",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scar 4",
+    "Enabled": true
   },
   "440258": {
     "OriginalText": "傷跡５",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scar 5",
+    "Enabled": true
   },
   "440259": {
     "OriginalText": "傷跡６",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scar 6",
+    "Enabled": true
   },
   "440260": {
     "OriginalText": "ソバカス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freckles",
+    "Enabled": true
   },
   "440261": {
     "OriginalText": "ナチュラルメイク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Natural Makeup",
+    "Enabled": true
   },
   "440262": {
     "OriginalText": "モデルメイク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Model Makeup",
+    "Enabled": true
   },
   "440263": {
     "OriginalText": "麗いメイク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Dark Makeup",
+    "Enabled": true
   },
   "440264": {
     "OriginalText": "リップカラー 赤",
-    "Text": "",
-    "Enabled": false
+    "Text": "Red Lip Color",
+    "Enabled": true
   },
   "440265": {
     "OriginalText": "リップカラー 紅",
-    "Text": "",
-    "Enabled": false
+    "Text": "Thick Red Lip Color",
+    "Enabled": true
   },
   "440266": {
     "OriginalText": "リップカラー 薄紅",
-    "Text": "",
-    "Enabled": false
+    "Text": "Thin Red Lip Color",
+    "Enabled": true
   },
   "440267": {
     "OriginalText": "リップカラー 橙",
-    "Text": "",
-    "Enabled": false
+    "Text": "Orange Lip Color",
+    "Enabled": true
   },
   "440268": {
     "OriginalText": "リップカラー 緑",
-    "Text": "",
-    "Enabled": false
+    "Text": "Green Lip Color",
+    "Enabled": true
   },
   "440269": {
     "OriginalText": "リップカラー 青",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blue Lip Color",
+    "Enabled": true
   },
   "440270": {
     "OriginalText": "リップカラー 紫",
-    "Text": "",
-    "Enabled": false
+    "Text": "Purple Lip Color",
+    "Enabled": true
   },
   "440271": {
     "OriginalText": "リップカラー 黒",
-    "Text": "",
-    "Enabled": false
+    "Text": "Black Lip Color",
+    "Enabled": true
   },
   "440272": {
     "OriginalText": "口ひげ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Moustasche",
+    "Enabled": true
   },
   "440273": {
     "OriginalText": "デスメタル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Death Metal",
+    "Enabled": true
   },
   "440274": {
     "OriginalText": "ひび（クラック）",
@@ -1306,18 +1306,18 @@
   },
   "440276": {
     "OriginalText": "キャスト用 ラインタイプＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Line Type A",
+    "Enabled": true
   },
   "440277": {
     "OriginalText": "キャスト用 ラインタイプＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Line Type B",
+    "Enabled": true
   },
   "440278": {
     "OriginalText": "キャスト用 ラインタイプＣ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Line Type C",
+    "Enabled": true
   },
   "440279": {
     "OriginalText": "絆創膏：セイル",
@@ -1336,23 +1336,23 @@
   },
   "440282": {
     "OriginalText": "タトゥー１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tattoo 1",
+    "Enabled": true
   },
   "440283": {
     "OriginalText": "胸のキズ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Chest Wound",
+    "Enabled": true
   },
   "440284": {
     "OriginalText": "男性用アンダーアーマー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Under Armor M",
+    "Enabled": true
   },
   "440285": {
     "OriginalText": "手のバンテージ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Hand Bandages",
+    "Enabled": true
   },
   "440286": {
     "OriginalText": "日焼跡",
@@ -1361,93 +1361,93 @@
   },
   "440287": {
     "OriginalText": "ニーソックス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Knee Socks",
+    "Enabled": true
   },
   "440288": {
     "OriginalText": "女性用アンダーアーマー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Under Armor F",
+    "Enabled": true
   },
   "440289": {
     "OriginalText": "タトゥー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tattoo",
+    "Enabled": true
   },
   "440290": {
     "OriginalText": "ガーターベルト＆ストッキング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Garter Belt & Stockings",
+    "Enabled": true
   },
   "440291": {
     "OriginalText": "ベレー帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beret Cap",
+    "Enabled": true
   },
   "440292": {
     "OriginalText": "ベレー帽 月",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beret Cap Moon",
+    "Enabled": true
   },
   "440293": {
     "OriginalText": "ベレー帽 夜",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beret Cap Night",
+    "Enabled": true
   },
   "440294": {
     "OriginalText": "ベレー帽 葉",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beret Cap Leaf",
+    "Enabled": true
   },
   "440295": {
     "OriginalText": "ベレー帽 陽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Beret Cap Sun",
+    "Enabled": true
   },
   "440296": {
     "OriginalText": "ヘッドギア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Headgear",
+    "Enabled": true
   },
   "440297": {
     "OriginalText": "ヘッドギア葉",
-    "Text": "",
-    "Enabled": false
+    "Text": "Headgear Leaf",
+    "Enabled": true
   },
   "440298": {
     "OriginalText": "ヘッドギア紅",
-    "Text": "",
-    "Enabled": false
+    "Text": "Headgear Crimson",
+    "Enabled": true
   },
   "440299": {
     "OriginalText": "ヘッドギア影",
-    "Text": "",
-    "Enabled": false
+    "Text": "Headgear Shadow",
+    "Enabled": true
   },
   "440300": {
     "OriginalText": "ヘッドギア月",
-    "Text": "",
-    "Enabled": false
+    "Text": "Headgear Moon",
+    "Enabled": true
   },
   "440301": {
     "OriginalText": "アイハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eye Hat",
+    "Enabled": true
   },
   "440302": {
     "OriginalText": "アイハット月",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eye Hat Moon",
+    "Enabled": true
   },
   "440303": {
     "OriginalText": "アイハット銀",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eye Hat Silver",
+    "Enabled": true
   },
   "440304": {
     "OriginalText": "アイハット影",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eye Hat Shadow",
+    "Enabled": true
   },
   "440305": {
     "OriginalText": "アイハット銅",
@@ -1456,23 +1456,23 @@
   },
   "440306": {
     "OriginalText": "ウィオラキャップ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Viola Cap",
+    "Enabled": true
   },
   "440307": {
     "OriginalText": "ウィオラキャップ夜",
-    "Text": "",
-    "Enabled": false
+    "Text": "Viola Cap Night",
+    "Enabled": true
   },
   "440308": {
     "OriginalText": "ウィオラキャップ影",
-    "Text": "",
-    "Enabled": false
+    "Text": "Viola Cap Shadow",
+    "Enabled": true
   },
   "440309": {
     "OriginalText": "ウィオラキャップ紅",
-    "Text": "",
-    "Enabled": false
+    "Text": "Viola Cap Crimson",
+    "Enabled": true
   },
   "440310": {
     "OriginalText": "ウィオラキャップ銅",
@@ -1481,13 +1481,13 @@
   },
   "440311": {
     "OriginalText": "背高帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tall Hat",
+    "Enabled": true
   },
   "440312": {
     "OriginalText": "背高帽 桜",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tall Hat Cherry",
+    "Enabled": true
   },
   "440313": {
     "OriginalText": "背高帽 産",
@@ -1496,198 +1496,198 @@
   },
   "440314": {
     "OriginalText": "背高帽 葉",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tall Hat Leaf",
+    "Enabled": true
   },
   "440315": {
     "OriginalText": "背高帽 陽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tall Hat Sun",
+    "Enabled": true
   },
   "440316": {
     "OriginalText": "クルーンハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Croon Hat",
+    "Enabled": true
   },
   "440317": {
     "OriginalText": "クルーンハット影",
-    "Text": "",
-    "Enabled": false
+    "Text": "Croon Hat Shadow",
+    "Enabled": true
   },
   "440318": {
     "OriginalText": "クルーンハット銀",
-    "Text": "",
-    "Enabled": false
+    "Text": "Croon Hat Silver",
+    "Enabled": true
   },
   "440319": {
     "OriginalText": "クルーンハット雅",
-    "Text": "",
-    "Enabled": false
+    "Text": "Croon Hat Elegance",
+    "Enabled": true
   },
   "440320": {
     "OriginalText": "クルーンハット月",
-    "Text": "",
-    "Enabled": false
+    "Text": "Croon Hat Moon",
+    "Enabled": true
   },
   "440321": {
     "OriginalText": "ヘッドセット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Headset",
+    "Enabled": true
   },
   "440322": {
     "OriginalText": "ヘッドアクセサリー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Head Accessory",
+    "Enabled": true
   },
   "440323": {
     "OriginalText": "トーク帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Toque Hat",
+    "Enabled": true
   },
   "440324": {
     "OriginalText": "略帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ordinary Cap",
+    "Enabled": true
   },
   "440325": {
     "OriginalText": "メイドカチューシャ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Maid Headband",
+    "Enabled": true
   },
   "440326": {
     "OriginalText": "ナースキャップＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nurse Cap A",
+    "Enabled": true
   },
   "440327": {
     "OriginalText": "シュノーケル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Snorkel",
+    "Enabled": true
   },
   "440328": {
     "OriginalText": "ヘイズハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Haze Hat",
+    "Enabled": true
   },
   "440329": {
     "OriginalText": "キャンディーヘッドギア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Candy Headgear",
+    "Enabled": true
   },
   "440330": {
     "OriginalText": "月桂樹の冠",
-    "Text": "",
-    "Enabled": false
+    "Text": "Laurel Wreath",
+    "Enabled": true
   },
   "440331": {
     "OriginalText": "ブラックテンガロンハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Black Ten Gallon Hat",
+    "Enabled": true
   },
   "440332": {
     "OriginalText": "レッドテンガロンハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Red Ten Gallon Hat",
+    "Enabled": true
   },
   "440333": {
     "OriginalText": "ホルスタインＴハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Holstein T Hat",
+    "Enabled": true
   },
   "440334": {
     "OriginalText": "ブラウンテンガロンハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Brown Ten Gallon Hat",
+    "Enabled": true
   },
   "440335": {
     "OriginalText": "ホワイトテンガロンハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "White Ten Gallon Hat",
+    "Enabled": true
   },
   "440336": {
     "OriginalText": "ブラウンキャスケット帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casquette Hat Brown",
+    "Enabled": true
   },
   "440337": {
     "OriginalText": "ホワイトキャスケット帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casquette Hat White",
+    "Enabled": true
   },
   "440338": {
     "OriginalText": "ピンクキャスケット帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casquette Hat Pink",
+    "Enabled": true
   },
   "440339": {
     "OriginalText": "ブラックキャスケット帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casquette Hat Black",
+    "Enabled": true
   },
   "440340": {
     "OriginalText": "イエローキャスケット帽",
-    "Text": "",
-    "Enabled": false
+    "Text": "Casquette Hat Yellow",
+    "Enabled": true
   },
   "440341": {
     "OriginalText": "プリムヘッドフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Prim Headphones",
+    "Enabled": true
   },
   "440342": {
     "OriginalText": "ブリッツガーダー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blitz Guarder",
+    "Enabled": true
   },
   "440343": {
     "OriginalText": "ヘッドゴーグル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Head Goggles",
+    "Enabled": true
   },
   "440344": {
     "OriginalText": "白ハチマキ",
-    "Text": "",
-    "Enabled": false
+    "Text": "White Headband",
+    "Enabled": true
   },
   "440345": {
     "OriginalText": "赤ハチマキ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Red Headband",
+    "Enabled": true
   },
   "440346": {
     "OriginalText": "ファニーリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Funny Ribbon",
+    "Enabled": true
   },
   "440347": {
-    "OriginalText": "シニヨン飾り ",
-    "Text": "",
-    "Enabled": false
+    "OriginalText": "シニヨン飾り",
+    "Text": "Chignon Decoration",
+    "Enabled": true
   },
   "440348": {
     "OriginalText": "カンカン帽Ａ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Boater A",
+    "Enabled": true
   },
   "440349": {
     "OriginalText": "カンカン帽Ｂ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Boater B",
+    "Enabled": true
   },
   "440350": {
     "OriginalText": "ナースキャップＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nurse Cap B",
+    "Enabled": true
   },
   "440351": {
     "OriginalText": "フランケンのネジ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Frankenscrew",
+    "Enabled": true
   },
   "440352": {
     "OriginalText": "魔女の付け鼻",
-    "Text": "",
-    "Enabled": false
+    "Text": "Witch Nose",
+    "Enabled": true
   },
   "440353": {
     "OriginalText": "マロンキャップ",
@@ -1711,113 +1711,113 @@
   },
   "440357": {
     "OriginalText": "フリューヘッド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Furieux Head",
+    "Enabled": true
   },
   "440358": {
     "OriginalText": "ファームイヤーマフ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Firm Earmuffs",
+    "Enabled": true
   },
   "440359": {
     "OriginalText": "チェックミニハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Checkered Mini Hat",
+    "Enabled": true
   },
   "440360": {
     "OriginalText": "モノクロミニハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Monochrome Mini Hat",
+    "Enabled": true
   },
   "440361": {
     "OriginalText": "ブレイカーズヘアバンド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Breakers Hairband",
+    "Enabled": true
   },
   "440362": {
     "OriginalText": "ブリンクバイザー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blink Visor",
+    "Enabled": true
   },
   "440363": {
     "OriginalText": "アルフマスク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alph Mask",
+    "Enabled": true
   },
   "440364": {
     "OriginalText": "ラッピーのたまご",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rappy Egg",
+    "Enabled": true
   },
   "440365": {
     "OriginalText": "ラッピーのヒナ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rappy Chick",
+    "Enabled": true
   },
   "440366": {
     "OriginalText": "大きなリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Big Ribbon",
+    "Enabled": true
   },
   "440367": {
     "OriginalText": "ツインリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Twin Ribbons",
+    "Enabled": true
   },
   "440368": {
     "OriginalText": "レッドオリエンタルリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Red Oriental Ribbon",
+    "Enabled": true
   },
   "440369": {
     "OriginalText": "イヤータイプＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ear Type A",
+    "Enabled": true
   },
   "440370": {
     "OriginalText": "イヤータイプＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ear Type B",
+    "Enabled": true
   },
   "440371": {
     "OriginalText": "イヤータイプＣ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ear Type C",
+    "Enabled": true
   },
   "440372": {
     "OriginalText": "アホ煽Ａ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ahoge A",
+    "Enabled": true
   },
   "440373": {
     "OriginalText": "アホ煽Ｂ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ahoge B",
+    "Enabled": true
   },
   "440374": {
     "OriginalText": "ふわふわ煽 小",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fluffy Hair Small",
+    "Enabled": true
   },
   "440375": {
     "OriginalText": "ふわふわ煽 中",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fluffy Hair Medium",
+    "Enabled": true
   },
   "440376": {
     "OriginalText": "ふわふわ煽 大",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fluffy Hair Large",
+    "Enabled": true
   },
   "440377": {
     "OriginalText": "ネコ耳",
-    "Text": "",
-    "Enabled": false
+    "Text": "Cat Ears",
+    "Enabled": true
   },
   "440378": {
     "OriginalText": "きつね耳",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fox Ears",
+    "Enabled": true
   },
   "440379": {
     "OriginalText": "たれきつね耳",
@@ -1836,208 +1836,208 @@
   },
   "440382": {
     "OriginalText": "クマ耳",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bear Ears",
+    "Enabled": true
   },
   "440383": {
     "OriginalText": "スコティッシュ耳",
-    "Text": "",
-    "Enabled": false
+    "Text": "Scottish Ears",
+    "Enabled": true
   },
   "440384": {
     "OriginalText": "きつねのおめんＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fox Mask B",
+    "Enabled": true
   },
   "440385": {
     "OriginalText": "きつねのおめんＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fox Mask A",
+    "Enabled": true
   },
   "440386": {
     "OriginalText": "ラッピーおめんＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rappy Mask B",
+    "Enabled": true
   },
   "440387": {
     "OriginalText": "ラッピーおめんＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rappy Mask A",
+    "Enabled": true
   },
   "440388": {
     "OriginalText": "ザウーダンおめんＢ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Za Oodan Mask B",
+    "Enabled": true
   },
   "440389": {
     "OriginalText": "ザウーダンおめんＡ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Za Oodan Mask A",
+    "Enabled": true
   },
   "440390": {
     "OriginalText": "ホッケーマスク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Hockey Mask",
+    "Enabled": true
   },
   "440391": {
     "OriginalText": "ラウンドメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Round Glasses",
+    "Enabled": true
   },
   "440392": {
     "OriginalText": "ラージラウンドメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Large Round Glasses",
+    "Enabled": true
   },
   "440393": {
     "OriginalText": "オーバルフチありメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Oval Rimmed Glasses",
+    "Enabled": true
   },
   "440394": {
     "OriginalText": "スクエアメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Square Glasses",
+    "Enabled": true
   },
   "440395": {
     "OriginalText": "ウェリントンメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Wellington Glasses",
+    "Enabled": true
   },
   "440396": {
     "OriginalText": "楕円メガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Oval Glasses",
+    "Enabled": true
   },
   "440397": {
     "OriginalText": "赤緑メガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Red-rimmed Glasses",
+    "Enabled": true
   },
   "440398": {
     "OriginalText": "スポーツサングラス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Sports Sunglasses",
+    "Enabled": true
   },
   "440399": {
     "OriginalText": "サイバーグラス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Cyber Glasses",
+    "Enabled": true
   },
   "440400": {
     "OriginalText": "ラウンドサングラス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Round Sunglasses",
+    "Enabled": true
   },
   "440401": {
     "OriginalText": "ラウンドサングラス 頭の上",
-    "Text": "",
-    "Enabled": false
+    "Text": "Round Sunglasses on Head",
+    "Enabled": true
   },
   "440402": {
     "OriginalText": "ゴーグル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Goggles",
+    "Enabled": true
   },
   "440403": {
     "OriginalText": "アイディスプレイ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eye Display",
+    "Enabled": true
   },
   "440404": {
     "OriginalText": "ハートメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Heart Glasses",
+    "Enabled": true
   },
   "440405": {
     "OriginalText": "スターメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Star Glasses",
+    "Enabled": true
   },
   "440406": {
     "OriginalText": "ぐるぐるメガネ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Swirly Swirly Glasses",
+    "Enabled": true
   },
   "440407": {
     "OriginalText": "ホワイトフェザーピアス",
-    "Text": "",
-    "Enabled": false
+    "Text": "White Feather Earrings",
+    "Enabled": true
   },
   "440408": {
     "OriginalText": "ブルーフェザーピアス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blue Feather Earrings",
+    "Enabled": true
   },
   "440409": {
     "OriginalText": "ピンクフェザーピアス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Pink Feather Earrings",
+    "Enabled": true
   },
   "440410": {
     "OriginalText": "金メダル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Gold Medal",
+    "Enabled": true
   },
   "440411": {
     "OriginalText": "銀メダル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Silver Medal",
+    "Enabled": true
   },
   "440412": {
     "OriginalText": "銅メダル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bronze Medal",
+    "Enabled": true
   },
   "440413": {
     "OriginalText": "錠前ネックレス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lock Necklace",
+    "Enabled": true
   },
   "440414": {
     "OriginalText": "ドクロネックレス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Skull Necklace",
+    "Enabled": true
   },
   "440415": {
     "OriginalText": "腕章",
-    "Text": "",
-    "Enabled": false
+    "Text": "Armband",
+    "Enabled": true
   },
   "440416": {
     "OriginalText": "腕章ピンク",
-    "Text": "",
-    "Enabled": false
+    "Text": "Pink Armband",
+    "Enabled": true
   },
   "440417": {
     "OriginalText": "腕章ナース",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nurse Armband",
+    "Enabled": true
   },
   "440418": {
     "OriginalText": "腕章ブルー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blue Armband",
+    "Enabled": true
   },
   "440419": {
     "OriginalText": "ピンクシュシュ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Pink Chouchou",
+    "Enabled": true
   },
   "440420": {
     "OriginalText": "ブルーシュシュ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blue Chouchou",
+    "Enabled": true
   },
   "440421": {
     "OriginalText": "パープルシュシュ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Purple Chouchou",
+    "Enabled": true
   },
   "440422": {
     "OriginalText": "トゲトゲのリストバンド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Spiked Wristband",
+    "Enabled": true
   },
   "440423": {
     "OriginalText": "ウサギの苔尾",
@@ -2051,48 +2051,48 @@
   },
   "440425": {
     "OriginalText": "ホワイトテイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "White Tail",
+    "Enabled": true
   },
   "440426": {
     "OriginalText": "イエローテイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Yellow Tail",
+    "Enabled": true
   },
   "440427": {
     "OriginalText": "茶リスのしっぽ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Brown Squirrel Tail",
+    "Enabled": true
   },
   "440428": {
     "OriginalText": "黄リスのしっぽ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Yellow Squirrel Tail",
+    "Enabled": true
   },
   "440429": {
     "OriginalText": "ブラウンフォックステイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Brown Fox Tail",
+    "Enabled": true
   },
   "440430": {
     "OriginalText": "イエローフォックステイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Yellow Fox Tail",
+    "Enabled": true
   },
   "440431": {
     "OriginalText": "ホワイトフォックステイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "White Fox Tail",
+    "Enabled": true
   },
   "440432": {
     "OriginalText": "ウォレットチェーン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Wallet Chain",
+    "Enabled": true
   },
   "440433": {
     "OriginalText": "背中のネジ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Back Screw",
+    "Enabled": true
   },
   "440434": {
     "OriginalText": "ラッピーリュック",
@@ -2116,233 +2116,233 @@
   },
   "440438": {
     "OriginalText": "サーキュエンデ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Circuende",
+    "Enabled": true
   },
   "440439": {
     "OriginalText": "サーキュエッジ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Circuedge",
+    "Enabled": true
   },
   "440440": {
     "OriginalText": "サーキュホーン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Circuhorn",
+    "Enabled": true
   },
   "440441": {
     "OriginalText": "ティルトウィン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tiltwin",
+    "Enabled": true
   },
   "440442": {
     "OriginalText": "ティラフラブ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tiraflove",
+    "Enabled": true
   },
   "440443": {
     "OriginalText": "ティレイギア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Tireigear",
+    "Enabled": true
   },
   "440444": {
     "OriginalText": "ブロストル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Brostol",
+    "Enabled": true
   },
   "440445": {
     "OriginalText": "ブロダング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Brodang",
+    "Enabled": true
   },
   "440446": {
     "OriginalText": "ブロワイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Browile",
+    "Enabled": true
   },
   "440447": {
     "OriginalText": "ファンブレア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fan Blair",
+    "Enabled": true
   },
   "440448": {
     "OriginalText": "フェニバイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fen Ibiel",
+    "Enabled": true
   },
   "440449": {
     "OriginalText": "ブルブリュート",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bulb Lute",
+    "Enabled": true
   },
   "440450": {
     "OriginalText": "ブルブヘッグス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bulb Heggs",
+    "Enabled": true
   },
   "440451": {
     "OriginalText": "バーウィン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Berwyn",
+    "Enabled": true
   },
   "440452": {
     "OriginalText": "バーティウィア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bertiwea",
+    "Enabled": true
   },
   "440453": {
     "OriginalText": "バーゴストゥ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bergost",
+    "Enabled": true
   },
   "440454": {
     "OriginalText": "サイマリス",
-    "Text": "",
-    "Enabled": false
+    "Text": "Psymalice",
+    "Enabled": true
   },
   "440455": {
     "OriginalText": "サイボルド",
-    "Text": "",
-    "Enabled": false
+    "Text": "Psyboard",
+    "Enabled": true
   },
   "440456": {
     "OriginalText": "サイテグラル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Psytegral",
+    "Enabled": true
   },
   "440457": {
     "OriginalText": "ショルドット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Shouldot",
+    "Enabled": true
   },
   "440458": {
     "OriginalText": "ショルディクター",
-    "Text": "",
-    "Enabled": false
+    "Text": "Shouldicter",
+    "Enabled": true
   },
   "440459": {
     "OriginalText": "ショルバキュドア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Shoulbacudol",
+    "Enabled": true
   },
   "440460": {
     "OriginalText": "クロスゲイナー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Crossgainer",
+    "Enabled": true
   },
   "440461": {
     "OriginalText": "クロスドメイン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Crossdomain",
+    "Enabled": true
   },
   "440462": {
     "OriginalText": "クロサリアン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Crossarian",
+    "Enabled": true
   },
   "440463": {
     "OriginalText": "ライザック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lyzac",
+    "Enabled": true
   },
   "440464": {
     "OriginalText": "ラジルザック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lazilzac",
+    "Enabled": true
   },
   "440465": {
     "OriginalText": "ラズリアザック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lazuliazac",
+    "Enabled": true
   },
   "440466": {
     "OriginalText": "カルバリアウィング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Calvaria Wing",
+    "Enabled": true
   },
   "440467": {
     "OriginalText": "ヘラストゥラ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Hera Sutra",
+    "Enabled": true
   },
   "440468": {
     "OriginalText": "ブルームフェザー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Bloom Feather",
+    "Enabled": true
   },
   "440469": {
     "OriginalText": "フェガリカット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Fegari Cut",
+    "Enabled": true
   },
   "440470": {
     "OriginalText": "ブリッツシンボル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Blitz Symbol",
+    "Enabled": true
   },
   "440471": {
     "OriginalText": "ミンストフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Minst Phon",
+    "Enabled": true
   },
   "440472": {
     "OriginalText": "ミンストブラン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Minst Blan",
+    "Enabled": true
   },
   "440473": {
     "OriginalText": "リュクスエール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Luxe Ale",
+    "Enabled": true
   },
   "440474": {
     "OriginalText": "リュクスソワール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Luxe Soir",
+    "Enabled": true
   },
   "440475": {
     "OriginalText": "ヤークトフェル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Jagd Fell",
+    "Enabled": true
   },
   "440476": {
     "OriginalText": "スロートフェル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Schlacht Fell",
+    "Enabled": true
   },
   "440477": {
     "OriginalText": "ヴォルウィング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vol Wing",
+    "Enabled": true
   },
   "440478": {
     "OriginalText": "ラグネスイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ragne Suile",
+    "Enabled": true
   },
   "440479": {
     "OriginalText": "ヴァーダーパック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vardha Pack",
+    "Enabled": true
   },
   "440480": {
     "OriginalText": "クォーツウィング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Quartz Wing",
+    "Enabled": true
   },
   "440481": {
     "OriginalText": "フリードアウトローアイパッチ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw Eyepatch",
+    "Enabled": true
   },
   "440482": {
     "OriginalText": "フリードアウトローＲハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw R Hat",
+    "Enabled": true
   },
   "440483": {
     "OriginalText": "レスペタンクバイオレット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Lespetank Violet",
+    "Enabled": true
   },
   "440484": {
     "OriginalText": "削除",
@@ -2351,68 +2351,68 @@
   },
   "440485": {
     "OriginalText": "アルキピューレＢバレッタ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Pure B Barette",
+    "Enabled": true
   },
   "440486": {
     "OriginalText": "リンデンドレスＧイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress G Earmuff",
+    "Enabled": true
   },
   "440487": {
     "OriginalText": "ラッピーミミクリキャップ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rappy Mimicry Cap",
+    "Enabled": true
   },
   "440488": {
     "OriginalText": "エイゲトグリーフイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eigeto Grief Earhook",
+    "Enabled": true
   },
   "440489": {
     "OriginalText": "アグリフォルスＷフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agri Fors W Headphone",
+    "Enabled": true
   },
   "440490": {
     "OriginalText": "エウリュードテイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eurude Tail",
+    "Enabled": true
   },
   "440491": {
     "OriginalText": "ガラティオンテイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Garation Tail",
+    "Enabled": true
   },
   "440492": {
     "OriginalText": "アルキファナティックスリーテイル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Fanatic Threetail",
+    "Enabled": true
   },
   "440493": {
     "OriginalText": "アグリオスバレル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agrios Barrel",
+    "Enabled": true
   },
   "440494": {
     "OriginalText": "クリトロキャップ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Critter Cap",
+    "Enabled": true
   },
   "440495": {
     "OriginalText": "エウリュードシェル",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eurude Shell",
+    "Enabled": true
   },
   "440496": {
     "OriginalText": "冒険ラッピーバックパック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Adventure Rappy Backpack",
+    "Enabled": true
   },
   "440497": {
     "OriginalText": "ガラティオンウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Garation Wings",
+    "Enabled": true
   },
   "440498": {
     "OriginalText": "削除",
@@ -2421,58 +2421,58 @@
   },
   "440499": {
     "OriginalText": "ゴルドスバックパック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Goldos Backpack",
+    "Enabled": true
   },
   "440500": {
     "OriginalText": "癒しのベアー",
-    "Text": "",
-    "Enabled": false
+    "Text": "Healing Bear",
+    "Enabled": true
   },
   "440501": {
     "OriginalText": "ノヴァトレートルＷウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor W Wings",
+    "Enabled": true
   },
   "440502": {
     "OriginalText": "ノヴァトレートルＷマント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor W Cloak",
+    "Enabled": true
   },
   "440503": {
     "OriginalText": "ギガンテスフラップ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Gigantes Flap",
+    "Enabled": true
   },
   "440504": {
     "OriginalText": "クロスタイ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Cross Tie",
+    "Enabled": true
   },
   "440505": {
     "OriginalText": "ギガンテスベント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Gigantes Vent",
+    "Enabled": true
   },
   "440506": {
     "OriginalText": "リンデンドレスツインテール",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress Twin Tail",
+    "Enabled": true
   },
   "440507": {
     "OriginalText": "アフォルバックパック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Afol Backpack",
+    "Enabled": true
   },
   "440508": {
     "OriginalText": "エイゲトリュゼウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Eigeto Ryuze Wings",
+    "Enabled": true
   },
   "440509": {
     "OriginalText": "ソフトクリームシャンプーハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Soft Cream Shampoo Hat",
+    "Enabled": true
   },
   "440510": {
     "OriginalText": "ファンタシーの翼",
@@ -2486,8 +2486,8 @@
   },
   "440512": {
     "OriginalText": "フローティングスフィア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Floating Sphere",
+    "Enabled": true
   },
   "440513": {
     "OriginalText": "ＤＬＣ用",
@@ -2496,68 +2496,68 @@
   },
   "440514": {
     "OriginalText": "ヘッドセット：リーティア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rietheia Headset",
+    "Enabled": true
   },
   "440515": {
     "OriginalText": "メガネ：レイヴァン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Raven Glasses",
+    "Enabled": true
   },
   "440516": {
     "OriginalText": "メガネ：キサラ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Kisara Glasses",
+    "Enabled": true
   },
   "440517": {
     "OriginalText": "メガネ：シャロン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Sharon Glasses",
+    "Enabled": true
   },
   "440518": {
     "OriginalText": "艦長の帽子",
-    "Text": "",
-    "Enabled": false
+    "Text": "Captain's Hat",
+    "Enabled": true
   },
   "440519": {
     "OriginalText": "艦長の腕章",
-    "Text": "",
-    "Enabled": false
+    "Text": "Captain's Armband",
+    "Enabled": true
   },
   "440520": {
     "OriginalText": "電子カルテ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Electronic Medical Record",
+    "Enabled": true
   },
   "440521": {
     "OriginalText": "カリストのスパナ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Callisto Spanner",
+    "Enabled": true
   },
   "440522": {
     "OriginalText": "腰スカートアーマー：ルティナ１",
-    "Text": "",
-    "Enabled": false
+    "Text": "Waist Skirt Armor: Lutina 1",
+    "Enabled": true
   },
   "440523": {
     "OriginalText": "腰スカートアーマー：ルティナ１リペア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Waist Skirt Armor: Lutina 1 Repair",
+    "Enabled": true
   },
   "440524": {
     "OriginalText": "腰スカートアーマー：ルティナ２\nフィルディアバージョン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Waist Skirt Armor: Lutina 2 - Fildia Ver.",
+    "Enabled": true
   },
   "440525": {
     "OriginalText": "腰スカートアーマー：フィルディア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Waist Skirt Armor: Fildia",
+    "Enabled": true
   },
   "440526": {
     "OriginalText": "腰スカートアーマー：フィルディアリペア",
-    "Text": "",
-    "Enabled": false
+    "Text": "Waist Skirt Armor: Fildia Repair",
+    "Enabled": true
   },
   "440527": {
     "OriginalText": "グラン発生伝置：ユノ",
@@ -2566,262 +2566,262 @@
   },
   "440528": {
     "OriginalText": "ジョーカ・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Joker Head (Damaged)",
+    "Enabled": true
   },
   "440529": {
     "OriginalText": "コロッサス・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Colossus Head (Damaged)",
+    "Enabled": true
   },
   "440530": {
     "OriginalText": "バルドル・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Baldur Head (Damaged)",
+    "Enabled": true
   },
   "440531": {
     "OriginalText": "ランクス・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Ranks Head (Damaged)",
+    "Enabled": true
   },
   "440532": {
     "OriginalText": "イルシオン・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Illusion Head (Damaged)",
+    "Enabled": true
   },
   "440533": {
     "OriginalText": "メディウム・ヘッド破",
-    "Text": "",
-    "Enabled": false
+    "Text": "Medium Head (Damaged)",
+    "Enabled": true
   },
   "440534": {
     "OriginalText": "ヴィテスシュタルクＫメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vites Schtark K Helmet",
+    "Enabled": true
   },
   "440535": {
     "OriginalText": "ヴィテスシュタルクＲメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vites Schtark R Helmet",
+    "Enabled": true
   },
   "440536": {
     "OriginalText": "ヴィテスシュタルクＹメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vites Schtark Y Helmet",
+    "Enabled": true
   },
   "440537": {
     "OriginalText": "ヴィテスシュタルクＢメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vites Schtark B Helmet",
+    "Enabled": true
   },
   "440538": {
     "OriginalText": "ヴィテスシュタルクＧメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vites Schtark G Helmet",
+    "Enabled": true
   },
   "440539": {
     "OriginalText": "フリードアウトローＲハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw R Hat",
+    "Enabled": true
   },
   "440540": {
     "OriginalText": "フリードアウトローＧハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw G Hat",
+    "Enabled": true
   },
   "440541": {
     "OriginalText": "フリードアウトローＯハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw O Hat",
+    "Enabled": true
   },
   "440542": {
     "OriginalText": "フリードアウトローＹハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw Y Hat",
+    "Enabled": true
   },
   "440543": {
     "OriginalText": "フリードアウトローＢハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Freed Outlaw B Hat",
+    "Enabled": true
   },
   "440544": {
     "OriginalText": "アルキピューレＢバレッタ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Pure B Barette",
+    "Enabled": true
   },
   "440545": {
     "OriginalText": "アルキピューレＶバレッタ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Pure V Barette",
+    "Enabled": true
   },
   "440546": {
     "OriginalText": "アルキピューレＹバレッタ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Pure Y Barette",
+    "Enabled": true
   },
   "440547": {
     "OriginalText": "アルキピューレＧバレッタ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Pure G Barette",
+    "Enabled": true
   },
   "440548": {
     "OriginalText": "アルキピューレＯバレッタ",
-    "Text": "",
-    "Enabled": false
+    "Text": "Alki Pure O Barette",
+    "Enabled": true
   },
   "440549": {
     "OriginalText": "アグリフォルスＷフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agri Fors W Headphone",
+    "Enabled": true
   },
   "440550": {
     "OriginalText": "アグリフォルスＲフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agri Fors R Headphone",
+    "Enabled": true
   },
   "440551": {
     "OriginalText": "アグリフォルスＫフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agri Fors K Headphone",
+    "Enabled": true
   },
   "440552": {
     "OriginalText": "アグリフォルスＢフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agri Fors B Headphone",
+    "Enabled": true
   },
   "440553": {
     "OriginalText": "アグリフォルスＧフォン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Agri Fors G Headphone",
+    "Enabled": true
   },
   "440554": {
     "OriginalText": "リンデンドレスＧイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress G Earmuff",
+    "Enabled": true
   },
   "440555": {
     "OriginalText": "リンデンドレスＶイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress V Earmuff",
+    "Enabled": true
   },
   "440556": {
     "OriginalText": "リンデンドレスＢイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress B Earmuff",
+    "Enabled": true
   },
   "440557": {
     "OriginalText": "リンデンドレスＲイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress R Earmuff",
+    "Enabled": true
   },
   "440558": {
     "OriginalText": "リンデンドレスＹイヤーフック",
-    "Text": "",
-    "Enabled": false
+    "Text": "Rinden Dress Y Earmuff",
+    "Enabled": true
   },
   "440559": {
     "OriginalText": "ノヴァトレートルＷウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor W Wing",
+    "Enabled": true
   },
   "440560": {
     "OriginalText": "ノヴァトレートルＲウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor R Wing",
+    "Enabled": true
   },
   "440561": {
     "OriginalText": "ノヴァトレートルＢウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor B Wing",
+    "Enabled": true
   },
   "440562": {
     "OriginalText": "ノヴァトレートルＫウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor K Wing",
+    "Enabled": true
   },
   "440563": {
     "OriginalText": "ノヴァトレートルＹウイング",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor Y Wing",
+    "Enabled": true
   },
   "440564": {
     "OriginalText": "ノヴァトレートルＷマント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor W Cloak",
+    "Enabled": true
   },
   "440565": {
     "OriginalText": "ノヴァトレートルＲマント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor R Cloak",
+    "Enabled": true
   },
   "440566": {
     "OriginalText": "ノヴァトレートルＢマント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor B Cloak",
+    "Enabled": true
   },
   "440567": {
     "OriginalText": "ノヴァトレートルＫマント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor K Cloak",
+    "Enabled": true
   },
   "440568": {
     "OriginalText": "ノヴァトレートルＹマント",
-    "Text": "",
-    "Enabled": false
+    "Text": "Nova Traitor Y Cloak",
+    "Enabled": true
   },
   "440569": {
     "OriginalText": "ヴィテスシュタルクＷメット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Vites Schtark W Helmet",
+    "Enabled": true
   },
   "440570": {
     "OriginalText": "ダイヤモンドネイヴＫハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Nave K Hat",
+    "Enabled": true
   },
   "440571": {
     "OriginalText": "ダイヤモンドネイヴＷハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Nave W Hat",
+    "Enabled": true
   },
   "440572": {
     "OriginalText": "ダイヤモンドクイーンＫリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Queen K Ribbon",
+    "Enabled": true
   },
   "440573": {
     "OriginalText": "ダイヤモンドクイーンＷリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Queen W Ribbon",
+    "Enabled": true
   },
   "440574": {
     "OriginalText": "ダイヤモンドネイヴＲハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Nave R Hat",
+    "Enabled": true
   },
   "440575": {
     "OriginalText": "ダイヤモンドネイヴＹハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Nave Y Hat",
+    "Enabled": true
   },
   "440576": {
     "OriginalText": "ダイヤモンドネイヴＢハット",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Nave B Hat",
+    "Enabled": true
   },
   "440577": {
     "OriginalText": "ダイヤモンドクイーンＢリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Queen B Ribbon",
+    "Enabled": true
   },
   "440578": {
     "OriginalText": "ダイヤモンドクイーンＲリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Queen R Ribbon",
+    "Enabled": true
   },
   "440579": {
     "OriginalText": "ダイヤモンドクイーンＹリボン",
-    "Text": "",
-    "Enabled": false
+    "Text": "Diamond Queen Y Ribbon",
+    "Enabled": true
   }
 }


### PR DESCRIPTION
The missing " has been added to "Spike". There's only a tiny chunk left to go through! New pull request because something went wrong, haha.

Nearly everything should be done now. Left to translate:
Eveything within the range of lines 422 to 495 remains untranslated.
In addition:

313: ニューマン（耳長）女性用アニメ系
318: ニューマン（耳短）女性用アニメ系
583: 太飼
588: 太飼（△型）
1018: ゆる三つ編み
1023: ゆる三つ編み 前
1033: 編みこみアップスタイル
1153: 鼻ばんそうこう
1173: 無精ひげ
1178: 隈取
1298: ひび（クラック）
1303: ツギハギ
1323: 絆創膏：セイル
1333: 胸煽
1358: 日焼跡
1453: アイハット銅 (One of the Eye Hats, but I'm not sure what it's "color" is supposed to be.)
1478: ウィオラキャップ銅 (One of the Viola Caps, but I'm not sure what it's "color" is supposed to be.)
1493: 背高帽 産 (One of the Tall Hats, but I'm not sure what it's "color" is supposed to be.)
1823: たれきつね耳 (Some ears.)
1828: 立ちうさ耳 (Some ears.)
1833: 践れうさ耳 (Some ears.)
2043: ウサギの苔尾
2048: 悪魔のしっぽ
2478: ファンタシーの翼
2483: ファンタシーの筒
2563: グラン発生伝置：ユノ

(Possibly) Off-limits do not touch:
2348: 削除
2418: 削除
2493: ＤＬＣ用