### PR TITLE
Magnas -> Magnus (マグナス)

### DIFF
--- a/rmd/Costumes.json
+++ b/rmd/Costumes.json
@@ -1551,7 +1551,7 @@
   },
   "330310": {
     "OriginalText": "マグナス",
-    "Text": "Magnas",
+    "Text": "Magnus",
     "Enabled": true
   },
   "330311": {

--- a/rmd/Credits.json
+++ b/rmd/Credits.json
@@ -71,7 +71,7 @@
   },
   "750014": {
     "OriginalText": "マグナス",
-    "Text": "Magnas",
+    "Text": "Magnus",
     "Enabled": true
   },
   "750015": {

--- a/rmd/NPCs.json
+++ b/rmd/NPCs.json
@@ -71,7 +71,7 @@
   },
   "30014": {
     "OriginalText": "マグナス",
-    "Text": "Magnas",
+    "Text": "Magnus",
     "Enabled": true
   },
   "30019": {


### PR DESCRIPTION
Pull request changing instances of Magnas to Magnus to resolve #392 .

Updated references in Credits.json, Costumes.json, and NPCs.json. 

There are some instances in **/csv/NpcBaseParameter.csv**, namely in line 9: 
`key5008,5008,TRUE,,np5008a_Magnas,0,,,,,,,,,,,,,,hunter,human,1,148,,203,,Magnas,530000,FD_magnas,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,TRUE,322400,,,,185,30014`

Not sure how these would be handled. Though it doesn't seem to matter for lines 7-8 pertaining to "Reven", which we seem to have corrected to "Raven" elsewhere.
