### PR TITLE
Fix characters silently dropped by the inserter

### DIFF
--- a/rmd/Communication Messages.json
+++ b/rmd/Communication Messages.json
@@ -1556,7 +1556,7 @@
   },
   "261525": {
     "OriginalText": "オラルカーネベア出現を確認。\n撃破目標の変更を緊急要請する。",
-    "Text": "Orale Carnnebear appearance detected.\nEmergency request, change your target to\bdefeat.",
+    "Text": "Orale Carnnebear appearance detected.\nEmergency request, change your target to defeat.",
     "Enabled": true
   },
   "261526": {

--- a/rmd/Materials.json
+++ b/rmd/Materials.json
@@ -941,7 +941,7 @@
   },
   "350188": {
     "OriginalText": "ロザードの完全な背びれ",
-    "Text": "Rozad Perfect Dorsal Fin​",
+    "Text": "Rozad Perfect Dorsal Fin",
     "Enabled": true
   },
   "350189": {
@@ -1546,7 +1546,7 @@
   },
   "350309": {
     "OriginalText": "トルリンプの大胸ビレ",
-    "Text": "Torrimp Large Pectoral Fin​",
+    "Text": "Torrimp Large Pectoral Fin",
     "Enabled": true
   },
   "350310": {

--- a/rmd/Menus.json
+++ b/rmd/Menus.json
@@ -426,32 +426,32 @@
   },
   "20001": {
     "OriginalText": "ヒューマン  男性",
-    "Text": "Human\tMale",
+    "Text": "Human Male",
     "Enabled": true
   },
   "20002": {
     "OriginalText": "ヒューマン  女性",
-    "Text": "Human\tFemale",
+    "Text": "Human Female",
     "Enabled": true
   },
   "20003": {
     "OriginalText": "ニューマン  男性",
-    "Text": "Newman\tMale",
+    "Text": "Newman Male",
     "Enabled": true
   },
   "20004": {
     "OriginalText": "ニューマン  女性",
-    "Text": "Newman\tFemale",
+    "Text": "Newman Female",
     "Enabled": true
   },
   "20005": {
     "OriginalText": "キャスト   男性",
-    "Text": "Cast\tMale",
+    "Text": "Cast Male",
     "Enabled": true
   },
   "20006": {
     "OriginalText": "キャスト   女性",
-    "Text": "Cast\tFemale",
+    "Text": "Cast Female",
     "Enabled": true
   },
   "20101": {
@@ -2921,12 +2921,12 @@
   },
   "22205": {
     "OriginalText": "日",
-    "Text": "\t",
+    "Text": " ",
     "Enabled": true
   },
   "22206": {
     "OriginalText": "人",
-    "Text": "\t",
+    "Text": " ",
     "Enabled": true
   },
   "22207": {
@@ -2956,7 +2956,7 @@
   },
   "22212": {
     "OriginalText": "名",
-    "Text": "\t",
+    "Text": " ",
     "Enabled": true
   },
   "22213": {

--- a/rmd/Promise Orders.json
+++ b/rmd/Promise Orders.json
@@ -2111,7 +2111,7 @@
   },
   "290140": {
     "OriginalText": "お前さんに託したい武器がある。\n俺の愛用のアヴェンジャーに匹敵する上洋だ。\nもし、受取る覚悟があるなら、コラル・ドラゴンを\n倒すことで俺に示してくれるか？\n[a 03]※この約束は１回のみ[b]",
-    "Text": "I have a weapon I want to entrust to you.\nIt’s as good as my Avenger. First, show\nme how you defeat a Coral Dragon?\n\n[a 03]※Non-Repeatable[b]",
+    "Text": "I have a weapon I want to entrust to you.\nIt's as good as my Avenger. First, show\nme how you defeat a Coral Dragon?\n\n[a 03]※Non-Repeatable[b]",
     "Enabled": true
   },
   "290141": {
@@ -4051,7 +4051,7 @@
   },
   "300246": {
     "OriginalText": "【グランピース（光属性）】を集める\n【グランピース（闇属性）】を集める",
-    "Text": "Collect [Gran Piece (Light)\nCollect [Gran Piece (Dark)]",
+    "Text": "Collect [Gran Piece (Light)]\nCollect [Gran Piece (Dark)]",
     "Enabled": true
   },
   "300247": {

--- a/rmd/Quests.json
+++ b/rmd/Quests.json
@@ -2206,12 +2206,12 @@
   },
   "230004": {
     "OriginalText": "\n銅の荒野における哨戒作戦を任せる。\n指定地域を周回探索せよ。\n原生種に遭遇した場合は速やかに撃破するよう。\n経贄を制圧し、治安確保を確認次第、\n帰還許可を与える。\n",
-    "Text": "\t",
+    "Text": " ",
     "Enabled": true
   },
   "230005": {
     "OriginalText": "\n銅の荒野におけるダーカー討伐作戦を任せる。\nダーカーの反応を多数確認している指定地域へ\n速やかに向かうよう。\nこの作戦は素材として利用するダーカーの確保が\n目的である。\n",
-    "Text": "\t",
+    "Text": " ",
     "Enabled": true
   },
   "230006": {
@@ -2221,7 +2221,7 @@
   },
   "230007": {
     "OriginalText": "\n銅の荒野における大型原生種\nジャッドバンサー撃破作戦を任せる。\n現在、エリア内の最深部に反応あり。\n速やかに現場へ向かうよう。\n標的の撃破を確認次第、帰還許可を与える。",
-    "Text": "\t",
+    "Text": " ",
     "Enabled": true
   },
   "230008": {
@@ -2726,7 +2726,7 @@
   },
   "230405": {
     "OriginalText": "\nノヴァ内部侵攻作戦を任せる。\nただし目的地にはダーカーが先行しており、\n原生種も展開している物様。\n大混戦となるおそれがあるが、ダーカーのみならず\n原生種の動きにも警戒し、最深部へ到達せよ。\n[a 03]\n※ギガンテスブラスト使用不可\n※シナリオクリアしたプレイヤーのみ参加可能[b]",
-    "Text": "\n[[a 03]※Gigantes Blast not allowed\n※Only players who cleared the scenario\ncan join[b]",
+    "Text": "\n[a 03]※Gigantes Blast not allowed\n※Only players who cleared the scenario\ncan join[b]",
     "Enabled": true
   },
   "230406": {

--- a/rmd/Search Team.json
+++ b/rmd/Search Team.json
@@ -861,7 +861,7 @@
   },
   "710064": {
     "OriginalText": "古代都市のエネミー掃討作戦に向かう。\n現地にて強い反応を確認しており、\nかなりの危険を伴う任務になると予想される。\n結果は追って報告する。",
-    "Text": "Large Torrimp Pectoral Fin​ × 5\nJurrakia Bone × 5\nSharp G-Shalurayda Arm Blade × 5",
+    "Text": "Large Torrimp Pectoral Fin × 5\nJurrakia Bone × 5\nSharp G-Shalurayda Arm Blade × 5",
     "Enabled": true
   },
   "710065": {
@@ -1561,7 +1561,7 @@
   },
   "730413": {
     "OriginalText": "休み、英気を養う。\n探索の成功に不可欠なものね。",
-    "Text": "Taking a break and rest. It’s\nessential to the success of the\nsearch.",
+    "Text": "Taking a break and rest. It's\nessential to the success of the\nsearch.",
     "Enabled": true
   },
   "730414": {

--- a/rmd/Story 2.json
+++ b/rmd/Story 2.json
@@ -1266,7 +1266,7 @@
   },
   "203020010050012": {
     "OriginalText": "ケーキ作りというのはとても繊細で、\n僅かな村料の違い、分量の差で出来が変化します。\n研究対象として実に興味深いです。",
-    "Text": "Making it is delicate, it will change\ndepending on the ingredients and quantity.\nIt’s really interesting subject for research.",
+    "Text": "Making it is delicate, it will change\ndepending on the ingredients and quantity.\nIt's really interesting subject for research.",
     "Enabled": true
   },
   "203020010060003": {
@@ -2291,7 +2291,7 @@
   },
   "205020010140013": {
     "OriginalText": "数頁年の間、誰も成し得なかった偉業です。",
-    "Text": "It’s a feat that no one could've ever done.",
+    "Text": "It's a feat that no one could've ever done.",
     "Enabled": true
   },
   "205020010150013": {

--- a/rmd/Story 5.json
+++ b/rmd/Story 5.json
@@ -396,7 +396,7 @@
   },
   "501000020090030": {
     "OriginalText": "警備部って……。\nああ。\nオルター内の警察みたいな部ですね。",
-    "Text": "What is the security force...?\nAahhh. It’s like a police force in ALTER.",
+    "Text": "What is the security force...?\nAahhh. It's like a police force in ALTER.",
     "Enabled": true
   },
   "501000020100031": {
@@ -871,7 +871,7 @@
   },
   "504000020200031": {
     "OriginalText": "そうだ。\nあなたにこれを渡しておきたかったんだ。\nコウエン隊長の記憶中枢だ。",
-    "Text": "Before I forgot.\nI want to give this to you.\nIt’s the memory drive of Captain Cowen.",
+    "Text": "Before I forgot.\nI want to give this to you.\nIt's the memory drive of Captain Cowen.",
     "Enabled": true
   },
   "504000020210031": {


### PR DESCRIPTION
These characters aren't in the game font, so the text inserter drops them, producing broken or blank text in-game:

- curly apostrophes (U+2019) -> straight '
- zero-width spaces (U+200B) -> removed
- tab and backspace escapes -> space

Also fixes two unbalanced/duplicated control-code brackets in Promise Orders and Quests that could corrupt parsing.

8 files, 24 lines. No translation wording changed — bug fixes.</title>