### PR TITLE
Fix non-rendering characters and malformed brackets

### DIFF
--- a/rmd/Materials.json
+++ b/rmd/Materials.json
@@ -941,7 +941,7 @@
   },
   "350188": {
     "OriginalText": "ロザードの完全な背びれ",
-    "Text": "Rozad Perfect Dorsal Fin​",
+    "Text": "Rozad Perfect Dorsal Fin",
     "Enabled": true
   },
   "350189": {
@@ -1546,7 +1546,7 @@
   },
   "350309": {
     "OriginalText": "トルリンプの大胸ビレ",
-    "Text": "Torrimp Large Pectoral Fin​",
+    "Text": "Torrimp Large Pectoral Fin",
     "Enabled": true
   },
   "350310": {

--- a/rmd/Promise Orders.json
+++ b/rmd/Promise Orders.json
@@ -2111,7 +2111,7 @@
   },
   "290140": {
     "OriginalText": "お前さんに託したい武器がある。\n俺の愛用のアヴェンジャーに匹敵する上洋だ。\nもし、受取る覚悟があるなら、コラル・ドラゴンを\n倒すことで俺に示してくれるか？\n[a 03]※この約束は１回のみ[b]",
-    "Text": "I have a weapon I want to entrust to you.\nIt’s as good as my Avenger. First, show\nme how you defeat a Coral Dragon?\n\n[a 03]※Non-Repeatable[b]",
+    "Text": "I have a weapon I want to entrust to you.\nIt's as good as my Avenger. First, show\nme how you defeat a Coral Dragon?\n\n[a 03]※Non-Repeatable[b]",
     "Enabled": true
   },
   "290141": {
@@ -4051,7 +4051,7 @@
   },
   "300246": {
     "OriginalText": "【グランピース（光属性）】を集める\n【グランピース（闇属性）】を集める",
-    "Text": "Collect [Gran Piece (Light)\nCollect [Gran Piece (Dark)]",
+    "Text": "Collect [Gran Piece (Light)]\nCollect [Gran Piece (Dark)]",
     "Enabled": true
   },
   "300247": {

--- a/rmd/Quests.json
+++ b/rmd/Quests.json
@@ -2726,7 +2726,7 @@
   },
   "230405": {
     "OriginalText": "\nノヴァ内部侵攻作戦を任せる。\nただし目的地にはダーカーが先行しており、\n原生種も展開している物様。\n大混戦となるおそれがあるが、ダーカーのみならず\n原生種の動きにも警戒し、最深部へ到達せよ。\n[a 03]\n※ギガンテスブラスト使用不可\n※シナリオクリアしたプレイヤーのみ参加可能[b]",
-    "Text": "\n[[a 03]※Gigantes Blast not allowed\n※Only players who cleared the scenario\ncan join[b]",
+    "Text": "\n[a 03]※Gigantes Blast not allowed\n※Only players who cleared the scenario\ncan join[b]",
     "Enabled": true
   },
   "230406": {

--- a/rmd/Search Team.json
+++ b/rmd/Search Team.json
@@ -861,7 +861,7 @@
   },
   "710064": {
     "OriginalText": "古代都市のエネミー掃討作戦に向かう。\n現地にて強い反応を確認しており、\nかなりの危険を伴う任務になると予想される。\n結果は追って報告する。",
-    "Text": "Large Torrimp Pectoral Fin​ × 5\nJurrakia Bone × 5\nSharp G-Shalurayda Arm Blade × 5",
+    "Text": "Large Torrimp Pectoral Fin × 5\nJurrakia Bone × 5\nSharp G-Shalurayda Arm Blade × 5",
     "Enabled": true
   },
   "710065": {
@@ -1561,7 +1561,7 @@
   },
   "730413": {
     "OriginalText": "休み、英気を養う。\n探索の成功に不可欠なものね。",
-    "Text": "Taking a break and rest. It’s\nessential to the success of the\nsearch.",
+    "Text": "Taking a break and rest. It's\nessential to the success of the\nsearch.",
     "Enabled": true
   },
   "730414": {

--- a/rmd/Story 2.json
+++ b/rmd/Story 2.json
@@ -1266,7 +1266,7 @@
   },
   "203020010050012": {
     "OriginalText": "ケーキ作りというのはとても繊細で、\n僅かな村料の違い、分量の差で出来が変化します。\n研究対象として実に興味深いです。",
-    "Text": "Making it is delicate, it will change\ndepending on the ingredients and quantity.\nIt’s really interesting subject for research.",
+    "Text": "Making it is delicate, it will change\ndepending on the ingredients and quantity.\nIt's really interesting subject for research.",
     "Enabled": true
   },
   "203020010060003": {
@@ -2291,7 +2291,7 @@
   },
   "205020010140013": {
     "OriginalText": "数頁年の間、誰も成し得なかった偉業です。",
-    "Text": "It’s a feat that no one could've ever done.",
+    "Text": "It's a feat that no one could've ever done.",
     "Enabled": true
   },
   "205020010150013": {

--- a/rmd/Story 5.json
+++ b/rmd/Story 5.json
@@ -396,7 +396,7 @@
   },
   "501000020090030": {
     "OriginalText": "警備部って……。\nああ。\nオルター内の警察みたいな部ですね。",
-    "Text": "What is the security force...?\nAahhh. It’s like a police force in ALTER.",
+    "Text": "What is the security force...?\nAahhh. It's like a police force in ALTER.",
     "Enabled": true
   },
   "501000020100031": {
@@ -871,7 +871,7 @@
   },
   "504000020200031": {
     "OriginalText": "そうだ。\nあなたにこれを渡しておきたかったんだ。\nコウエン隊長の記憶中枢だ。",
-    "Text": "Before I forgot.\nI want to give this to you.\nIt’s the memory drive of Captain Cowen.",
+    "Text": "Before I forgot.\nI want to give this to you.\nIt's the memory drive of Captain Cowen.",
     "Enabled": true
   },
   "504000020210031": {


### PR DESCRIPTION
MERGE PLEASE

- curly apostrophes (U+2019) -> straight ' (per the style guide)
- trailing/embedded zero-width spaces (U+200B) -> removed
- Promise Orders: close an unbalanced item bracket
- Quests: remove a duplicated '[' before a color code
